### PR TITLE
Use NodeState#disable instead of NodeState#stop.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nsqjs",
   "description": "NodeJS client for NSQ",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "homepage": "https://github.com/dudleycarr/nsqjs",
   "author": {
     "name": "Dudley Carr",

--- a/src/nsqdconnection.coffee
+++ b/src/nsqdconnection.coffee
@@ -281,7 +281,7 @@ class ConnectionState extends NodeState
           cb? err
         @conn.messageCallbacks = []
 
-        @stop()
+        @disable()
         @conn.destroy()
         @conn.emit NSQDConnection.CLOSED
         delete @conn


### PR DESCRIPTION
NodeState#disable truly turns off the FSM. It calls NodeState#stop internally, 
but it sets the disabled flag as well, which is checked inside wrapped
callbacks and before any transitions.

https://github.com/ichernev/node-state/blob/master/lib/nodestate.js#L127 
https://github.com/ichernev/node-state/blob/master/lib/nodestate.js#L62 
https://github.com/ichernev/node-state/blob/master/lib/nodestate.js#L150
