### PR TITLE
Added support for the new ephemeral topic feature

### DIFF
--- a/src/wire.coffee
+++ b/src/wire.coffee
@@ -136,7 +136,7 @@ exports.auth = (token) ->
   command 'AUTH', token
 
 validTopicName = (topic) ->
-  (0 < topic.length < 33) and topic.match(/^[\.a-zA-Z0-9_-]+$/)?
+  (0 < topic.length < 33) and topic.match(/^[\.a-zA-Z0-9_-]+(#ephemeral)$/)?
 
 validChannelName = (channel) ->
   channelRe = /^[\.a-zA-Z0-9_-]+(#ephemeral)?$/


### PR DESCRIPTION
The new version of NSQ supports ephemeral topics for true pub sub functionality. I changed the regex for the topic name validation to support this.
