### PR TITLE
Fix AUTH state transition

### DIFF
--- a/src/nsqdconnection.coffee
+++ b/src/nsqdconnection.coffee
@@ -324,6 +324,7 @@ class ConnectionState extends NodeState
       Enter: ->
         return @goto @afterIdentify() unless @conn.config.authSecret
         @conn.write wire.auth @conn.config.authSecret
+        return @goto 'AUTH_RESPONSE'
 
     AUTH_RESPONSE:
       response: (data) ->


### PR DESCRIPTION
In the current master, when negotiating with a TLS connection, after presenting `authSecret`, the server response with auth identity, however that's not being handled. 

This is expected transition for TLS connect, however I do not know if it conflicts with other implementation. 
