### PR TITLE
Update Lookupd address routine to support full URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ options object.
   A string or an array of string representing the host/port pair for nsqd instances.
   <br/> For example: `['localhost:4150']`
 * ```lookupdHTTPAddresses``` <br/>
-  A string or an array of strings representing the host/port pair of nsqlookupd instaces.
-  <br/> For example: `['localhost:4161']`
+  A string or an array of strings representing the host/port pair of nsqlookupd instaces or the full HTTP/HTTPS URIs of the nsqlookupd instances.
+  <br/> For example: `['localhost:4161']`, `['http://localhost/lookup']`, `['http://localhost/path/lookup?extra_param=true']`
 * ```lookupdPollInterval: 60``` <br/>
   The frequency in seconds for querying lookupd instances.
 * ```lookupdPollJitter: 0.3``` <br/>

--- a/src/lookupd.coffee
+++ b/src/lookupd.coffee
@@ -1,6 +1,7 @@
 _ = require 'underscore'
 async = require 'async'
 request = require 'request'
+url = require 'url'
 
 ###
 lookupdRequest returns the list of producers from a lookupd given a URL to
@@ -77,7 +78,14 @@ Arguments:
 ###
 lookup = (lookupdEndpoints, topic, callback) ->
   endpointURL = (endpoint) ->
-    "http://#{endpoint}/lookup?topic=#{topic}"
+    endpoint = "http://#{endpoint}" if endpoint.indexOf('://') is -1
+    parsedUrl = url.parse endpoint, true
+
+    if (not parsedUrl.pathname) or (parsedUrl.pathname is '/')
+      parsedUrl.pathname = "/lookup"
+    parsedUrl.query.topic = topic
+    delete parsedUrl.search
+    url.format(parsedUrl)
   dedupedRequests lookupdEndpoints, endpointURL, callback
 
 module.exports = lookup

--- a/test/config_test.coffee
+++ b/test/config_test.coffee
@@ -104,19 +104,38 @@ describe 'ConnectionConfig', ->
         config.isBoolean 'tls', 'hi'
       check.should.throw()
 
-  describe 'isAddressList', ->
+  describe 'isBareAddresses', ->
     it 'should validate against a validate address list of 1', ->
       check = ->
-        config.isAddressList 'nsqdTCPAddresses', ['127.0.0.1:4150']
+        config.isBareAddresses 'nsqdTCPAddresses', ['127.0.0.1:4150']
       check.should.not.throw()
     it 'should validate against a validate address list of 2', ->
       check = ->
         addrs = ['127.0.0.1:4150', 'localhost:4150']
-        config.isAddressList 'nsqdTCPAddresses', addrs
+        config.isBareAddresses 'nsqdTCPAddresses', addrs
       check.should.not.throw()
     it 'should not validate non-numeric port', ->
       check = ->
-        config.isAddressList 'nsqdTCPAddresses', ['localhost']
+        config.isBareAddresses 'nsqdTCPAddresses', ['localhost']
+      check.should.throw()
+
+  describe 'isLookupdHTTPAddresses', ->
+    it 'should validate against a validate address list of 1', ->
+      check = ->
+        config.isLookupdHTTPAddresses 'lookupdHTTPAddresses', ['127.0.0.1:4150']
+      check.should.not.throw()
+    it 'should validate against a validate address list of 2', ->
+      check = ->
+        addrs = ['127.0.0.1:4150', 'localhost:4150', 'http://localhost/nsq/lookup', 'https://localhost/nsq/lookup']
+        config.isLookupdHTTPAddresses 'lookupdHTTPAddresses', addrs
+      check.should.not.throw()
+    it 'should not validate non-numeric port', ->
+      check = ->
+        config.isLookupdHTTPAddresses 'lookupdHTTPAddresses', ['localhost']
+      check.should.throw()
+    it 'should not validate non-HTTP/HTTPs address', ->
+      check = ->
+        config.isLookupdHTTPAddresses 'lookupdHTTPAddresses', ['localhost']
       check.should.throw()
 
 


### PR DESCRIPTION
Updated Lookupd address to support full HTTP/HTTPS URI format

This should address #44

Go implementation: https://github.com/bitly/go-nsq/blob/master/consumer.go#L381-L405
