### PR TITLE
invoke callback with an error if the connection is closed when publishin...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nsqjs",
   "description": "NodeJS client for NSQ",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "homepage": "https://github.com/dudleycarr/nsqjs",
   "author": {
     "name": "Dudley Carr",

--- a/src/writer.coffee
+++ b/src/writer.coffee
@@ -67,7 +67,7 @@ class Writer extends EventEmitter
       a list of string / buffers / JSON serializable objects.
   ###
   publish: (topic, msgs, callback) ->
-    if not @conn or @conn.connectionState().current_state_name is 'CLOSED'
+    if not @conn or @conn.connectionState and @conn.connectionState().current_state_name is 'CLOSED'
       err = new Error 'No active Writer connection to send messages'
 
     if not msgs or _.isEmpty msgs

--- a/src/writer.coffee
+++ b/src/writer.coffee
@@ -67,7 +67,7 @@ class Writer extends EventEmitter
       a list of string / buffers / JSON serializable objects.
   ###
   publish: (topic, msgs, callback) ->
-    unless @conn
+    if not @conn or @conn.connectionState().current_state_name is 'CLOSED'
       err = new Error 'No active Writer connection to send messages'
 
     if not msgs or _.isEmpty msgs


### PR DESCRIPTION
if the connection to NSQD was lost, publishing a message didn't return an error in the callback.

added a verification that the connection is also NOT closed when publishing a message.