### PR TITLE
Better detection of message publish failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ node_js:
   - "0.10"
 before_script:
   - npm install -g grunt-cli
-  - wget "https://s3.amazonaws.com/bitly-downloads/nsq/nsq-0.3.0.linux-amd64.go1.3.3.tar.gz"
+  - wget "https://s3.amazonaws.com/bitly-downloads/nsq/nsq-0.3.2.linux-amd64.go1.4.1.tar.gz"
   - tar zvxf "nsq-0.3.2.linux-amd64.go1.4.1.tar.gz"
   - export PATH="$PATH:./nsq-0.3.2.linux-amd64.go1.4.1/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ node_js:
 before_script:
   - npm install -g grunt-cli
   - wget "https://s3.amazonaws.com/bitly-downloads/nsq/nsq-0.3.0.linux-amd64.go1.3.3.tar.gz"
-  - tar zvxf "nsq-0.3.0.linux-amd64.go1.3.3.tar.gz"
-  - export PATH="$PATH:./nsq-0.3.0.linux-amd64.go1.3.3/bin"
+  - tar zvxf "nsq-0.3.2.linux-amd64.go1.4.1.tar.gz"
+  - export PATH="$PATH:./nsq-0.3.2.linux-amd64.go1.4.1/bin"

--- a/src/writer.coffee
+++ b/src/writer.coffee
@@ -89,8 +89,6 @@ class Writer extends EventEmitter
       return callback err if callback
       throw err
 
-    # TODO: Add CONNECTING event.
-
     # Call publish again once the Writer is ready.
     unless @ready
       @on Writer.READY, (err) =>

--- a/test/integration_test.coffee
+++ b/test/integration_test.coffee
@@ -242,12 +242,18 @@ describe 'integration', ->
 
         done()
 
-#   it.only 'should successfully publish a message before fully connected', (done) ->
-#     writer = new nsq.Writer '127.0.0.1', 4150
-#     writer.publish 'a_topic', 'a message', (err) ->
-#       err.should.not.exist
-#       done()
-#     writer.connect()
+    it 'should successfully publish a message before fully connected', (done) ->
+      writer = new nsq.Writer '127.0.0.1', TCP_PORT
+      writer.connect()
+
+      # The writer is connecting, but it shouldn't be ready to publish.
+      writer.ready.should.eql false
+
+      # Publish the message. It should succeed since the writer will queue up
+      # the message while connecting.
+      writer.publish 'a_topic', 'a message', (err) ->
+        should.not.exist err
+        done()
 
 
 describe 'failures', ->
@@ -281,7 +287,7 @@ describe 'failures', ->
           # Attempt to publish a message.
           (callback) ->
             writer.publish 'test_topic', 'a message that should fail', (err) ->
-              err.should.exist
+              should.exist err
               callback()
         ], (err) ->
           done()

--- a/test/integration_test.coffee
+++ b/test/integration_test.coffee
@@ -148,7 +148,8 @@ describe 'integration', ->
 
     it 'should send and receive a string', (done) ->
       message = 'hello world'
-      writer.publish topic, message
+      writer.publish topic, message, (err) ->
+        done err if err
 
       reader.on 'message', (msg) ->
         msg.body.toString().should.eql message
@@ -276,7 +277,7 @@ describe 'failures', ->
           # Stop the nsqd process.
           (callback) ->
             nsqdProcess.kill()
-            setTimeout callback, 500
+            setTimeout callback, 10
           # Attempt to publish a message.
           (callback) ->
             writer.publish 'test_topic', 'a message that should fail', (err) ->

--- a/test/integration_test.coffee
+++ b/test/integration_test.coffee
@@ -255,18 +255,15 @@ describe 'integration', ->
         should.not.exist err
         done()
 
-
 describe 'failures', ->
-  nsqdProcess = null
-
   before (done) ->
-    temp.mkdir '/nsq', (err, dirPath) ->
-      startNSQD dirPath, {}, (err, process) ->
-        nsqdProcess = process
+    temp.mkdir '/nsq', (err, dirPath) =>
+      startNSQD dirPath, {}, (err, process) =>
+        @nsqdProcess = process
         done err
 
   after (done) ->
-    nsqdProcess.kill()
+    @nsqdProcess.kill()
     # Give nsqd a chance to exit before it's data directory will be cleaned up.
     setTimeout done, 500
 
@@ -281,8 +278,8 @@ describe 'failures', ->
             writer.on 'ready', ->
               callback()
           # Stop the nsqd process.
-          (callback) ->
-            nsqdProcess.kill()
+          (callback) =>
+            @nsqdProcess.kill()
             setTimeout callback, 10
           # Attempt to publish a message.
           (callback) ->
@@ -290,4 +287,4 @@ describe 'failures', ->
               should.exist err
               callback()
         ], (err) ->
-          done()
+          done err

--- a/test/nsqdconnection_test.coffee
+++ b/test/nsqdconnection_test.coffee
@@ -36,14 +36,14 @@ describe 'Reader ConnectionState', ->
 
   it 'handle initial handshake', ->
     {statemachine, sent} = state
-    statemachine.start()
+    statemachine.raise 'connected'
 
     sent[0].should.match /^  V2$/
     sent[1].should.match /^IDENTIFY/
 
   it 'handle OK identify response', ->
     {statemachine, connection} = state
-    statemachine.start()
+    statemachine.raise 'connected'
     statemachine.raise 'response', new Buffer('OK')
 
     connection.maxRdyCount.should.eq 2500
@@ -52,7 +52,7 @@ describe 'Reader ConnectionState', ->
 
   it 'handle identify response', ->
     {statemachine, connection} = state
-    statemachine.start()
+    statemachine.raise 'connected'
 
     statemachine.raise 'response', JSON.stringify
       max_rdy_count: 1000
@@ -69,7 +69,7 @@ describe 'Reader ConnectionState', ->
       # Subscribe notification
       done()
 
-    statemachine.start()
+    statemachine.raise 'connected'
     statemachine.raise 'response', 'OK' # Identify response
 
     sent[2].should.match /^SUB topic_test channel_test\n$/
@@ -81,7 +81,7 @@ describe 'Reader ConnectionState', ->
     connection.on NSQDConnection.MESSAGE, (msg) ->
       done()
 
-    statemachine.start()
+    statemachine.raise 'connected'
     statemachine.raise 'response', 'OK' # Identify response
     statemachine.raise 'response', 'OK' # Subscribe response
 
@@ -102,7 +102,7 @@ describe 'Reader ConnectionState', ->
       setTimeout fin, 10
 
     # Advance the connection to the READY state.
-    statemachine.start()
+    statemachine.raise 'connected'
     statemachine.raise 'response', 'OK' # Identify response
     statemachine.raise 'response', 'OK' # Subscribe response
 
@@ -146,7 +146,7 @@ describe 'WriterConnectionState', ->
       statemachine.current_state_name.should.eq 'READY_SEND'
       done()
 
-    statemachine.start()
+    statemachine.raise 'connected'
     statemachine.raise 'response', 'OK' # Identify response
 
   it 'should use PUB when sending a single message', (done) ->
@@ -157,7 +157,7 @@ describe 'WriterConnectionState', ->
       sent[sent.length-1].should.match /^PUB/
       done()
 
-    statemachine.start()
+    statemachine.raise 'connected'
     statemachine.raise 'response', 'OK' # Identify response
 
   it 'should use MPUB when sending multiplie messages', (done) ->
@@ -168,7 +168,7 @@ describe 'WriterConnectionState', ->
       sent[sent.length-1].should.match /^MPUB/
       done()
 
-    statemachine.start()
+    statemachine.raise 'connected'
     statemachine.raise 'response', 'OK' # Identify response
 
   it 'should call the callback when supplied on publishing a message', (done) ->
@@ -180,7 +180,7 @@ describe 'WriterConnectionState', ->
 
       statemachine.raise 'response', 'OK' # Message response
 
-    statemachine.start()
+    statemachine.raise 'connected'
     statemachine.raise 'response', 'OK' # Identify response
 
   it 'should call the the right callback on several messages', (done) ->
@@ -196,7 +196,7 @@ describe 'WriterConnectionState', ->
       statemachine.raise 'response', 'OK' # Message response
       statemachine.raise 'response', 'OK' # Message response
 
-    statemachine.start()
+    statemachine.raise 'connected'
     statemachine.raise 'response', 'OK' # Identify response
 
   it 'should call all callbacks on nsqd disconnect', (done) ->
@@ -218,5 +218,5 @@ describe 'WriterConnectionState', ->
       expect(secondCb.calledOnce).is.ok
       done()
 
-    statemachine.start()
+    statemachine.raise 'connected'
     statemachine.raise 'response', 'OK' # Identify response

--- a/test/writer_test.coffee
+++ b/test/writer_test.coffee
@@ -105,5 +105,5 @@ describe 'writer', ->
     it 'should fail when the Writer is not connected', (done) ->
       writer = new nsq.Writer '127.0.0.1', '4150'
       writer.publish 'test_topic', 'a briliant message', (err) ->
-        err.should.not.exist
+        err.should.exist
         done()

--- a/test/writer_test.coffee
+++ b/test/writer_test.coffee
@@ -101,3 +101,9 @@ describe 'writer', ->
       writer.publish topic, msg, (err) ->
         err.should.exist
         done()
+
+    it 'should fail when the Writer is not connected', (done) ->
+      writer = new nsq.Writer '127.0.0.1', '4150'
+      writer.publish 'test_topic', 'a briliant message', (err) ->
+        err.should.not.exist
+        done()


### PR DESCRIPTION
Publish on a writer will generate an error under the following conditions:
1. Writer is instantiated, but connect hasn't been called.
2. Writer has received an error.
3. Writer connection is closed.

If a message is publishing while the Writer is connecting, then it will wait for the ready event to publish or it will error out as soon as it gets an error event or a closed event.

Fixes: #53 