### PR TITLE
Specify grunt-cli in dev-deps and use for test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ install:
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
   - $CXX --version
   - npm install
-  - npm install -g grunt-cli
   - wget "https://s3.amazonaws.com/bitly-downloads/nsq/nsq-0.3.5.linux-amd64.go1.4.2.tar.gz"
   - tar zvxf "nsq-0.3.5.linux-amd64.go1.4.2.tar.gz"
   - export PATH="$PATH:./nsq-0.3.5.linux-amd64.go1.4.2/bin"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build": "coffee --bare --compile --output lib src/*.coffee",
     "prepublish": "coffee --bare --compile --output lib src/*.coffee",
     "postpublish": "rm -rf lib",
-    "test": "grunt test"
+    "test": "node_modules/.bin/grunt test"
   },
   "engines": {
     "node": ">= 0.10.0"
@@ -45,6 +45,7 @@
     "coffee-script": "~1.6.3",
     "coffeelint": "~1.0.2",
     "grunt": "~0.4.1",
+    "grunt-cli": "^0.1.13",
     "grunt-coffeelint": "0.0.8",
     "grunt-contrib-coffee": "~0.7",
     "grunt-contrib-watch": "~0.5.1",


### PR DESCRIPTION
Makes sense to specify the version of `grunt-cli` in the package file and use the project-local version for testing. This shouldn't need a version bump.