### PR TITLE
Differentiate non-fatal errors from fatal errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ w.on Writer.CLOSED, ->
 
 Changes
 -------
+* **0.7.9**
+  * Treat non-fatal errors appropriately
 * **0.7.7**
   * Build with Node v4
 * **0.7.6**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nsqjs",
   "description": "NodeJS client for NSQ",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "homepage": "https://github.com/dudleycarr/nsqjs",
   "author": {
     "name": "Dudley Carr",

--- a/src/nsqdconnection.coffee
+++ b/src/nsqdconnection.coffee
@@ -413,7 +413,15 @@ class ConnectionState extends NodeState
         cb? err
 
         @conn.emit NSQDConnection.ERROR, err
-        @goto 'CLOSED'
+
+        # According to NSQ docs, the following errors are non-fatal and should
+        # not close the connection. See here for more info:
+        # http://nsq.io/clients/building_client_libraries.html
+        errorCode = err.split(/\s+/)?[1]
+        if errorCode in ['E_REQ_FAILED', 'E_FIN_FAILED', 'E_TOUCH_FAILED']
+          @goto 'READY_RECV'
+        else
+          @goto 'CLOSED'
 
       close: ->
         @goto 'CLOSED'


### PR DESCRIPTION
The [NSQ documentation](http://nsq.io/clients/building_client_libraries.html) classifies some NSQD errors as fatal and others as non-fatal. Non-fatal errors should not close the socket because they are intermittent, so there's no need to close the connection.