### PR TITLE
Fix error split exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ w.on Writer.CLOSED, ->
 
 Changes
 -------
+* **0.7.10**
+  * Properly handles non-string errors
 * **0.7.9**
   * Treat non-fatal errors appropriately
 * **0.7.7**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nsqjs",
   "description": "NodeJS client for NSQ",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "homepage": "https://github.com/dudleycarr/nsqjs",
   "author": {
     "name": "Dudley Carr",

--- a/src/nsqdconnection.coffee
+++ b/src/nsqdconnection.coffee
@@ -417,6 +417,7 @@ class ConnectionState extends NodeState
         # According to NSQ docs, the following errors are non-fatal and should
         # not close the connection. See here for more info:
         # http://nsq.io/clients/building_client_libraries.html
+        err = err.toString() unless _.isString err
         errorCode = err.split(/\s+/)?[1]
         if errorCode in ['E_REQ_FAILED', 'E_FIN_FAILED', 'E_TOUCH_FAILED']
           @goto 'READY_RECV'

--- a/test/nsqdconnection_test.coffee
+++ b/test/nsqdconnection_test.coffee
@@ -122,7 +122,7 @@ describe 'Reader ConnectionState', ->
     connection.on NSQDConnection.CLOSED, ->
       done new Error 'Should not have closed!'
 
-    statemachine.goto 'ERROR', 'Error: E_REQ_FAILED'
+    statemachine.goto 'ERROR', new Error 'E_REQ_FAILED'
 
 describe 'WriterConnectionState', ->
   state =


### PR DESCRIPTION
Errors emitted are not always strings, so coerce any non-string error to a string before splitting to inspect the error code.