### PR TITLE
Clarify maxAttempts documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ options object.
   The maximum amount of time (seconds) the Reader will backoff for any single backoff
   event.
 * ```maxAttempts: 0``` <br/>
-  The number of times to a message can be requeued before it will be handed to the DISCARD handler and then automatically finished. 0 means that there is **no limit.** If no DISCARD handler is specified and `maxAttempts > 0`, then the message will be finished automatically when the number of attempts has been exhausted.
+  The number of times a given message will be attempted (given to MESSAGE handler) before it will be handed to the DISCARD handler and then automatically finished. 0 means that there is **no limit.** If no DISCARD handler is specified and `maxAttempts > 0`, then the message will be finished automatically when the number of attempts has been exhausted.
 * ```requeueDelay: 90``` <br/>
   The default amount of time (seconds) a message requeued should be delayed by before being dispatched by nsqd.
 * ```nsqdTCPAddresses``` <br/>


### PR DESCRIPTION
Clarifies the behavior of the `maxAttempts` config option.

Fixes https://github.com/dudleycarr/nsqjs/issues/109