### PR TITLE
Clear timeout timers when responding to messages.

### DIFF
--- a/src/message.coffee
+++ b/src/message.coffee
@@ -18,6 +18,7 @@ class Message extends EventEmitter
     @receivedOn = Date.now()
     @lastTouched = @receivedOn
     @touchCount = 0
+    @trackTimeoutId = null
 
     # Keep track of when this message actually times out.
     @timedOut = false
@@ -29,7 +30,9 @@ class Message extends EventEmitter
 
       # Both values have to be not null otherwise we've timedout.
       @timedOut = not soft or not hard
-      setTimeout trackTimeout, Math.min soft, hard unless @timedOut
+      unless @timedOut
+        clearTimeout @trackTimeoutId
+        @trackTimeoutId = setTimeout trackTimeout, Math.min soft, hard
 
   json: ->
     unless @parsed?
@@ -74,6 +77,8 @@ class Message extends EventEmitter
     process.nextTick =>
       if responseType isnt Message.TOUCH
         @hasResponded = true
+        clearTimeout @trackTimeoutId
+        @trackTimeoutId = null
       else
         @lastTouched = Date.now()
 

--- a/test/integration_test.coffee
+++ b/test/integration_test.coffee
@@ -183,7 +183,7 @@ describe 'integration', ->
       reader.on 'message', (msg) ->
         msg.finish()
         clearTimeout timeout
-        waitedLongEnough.should.be.true
+        waitedLongEnough.should.be.true()
         done()
 
       writer.publish topic, 'pause test'
@@ -193,7 +193,7 @@ describe 'integration', ->
 
       reader.on 'message', (msg) ->
         # check the message
-        msg.json().messageShouldArrive.should.be.true
+        msg.json().messageShouldArrive.should.be.true()
         msg.finish()
 
         if reader.isPaused() then return done()
@@ -228,7 +228,7 @@ describe 'integration', ->
       writer.publish topic, sentWhilePaused: false
 
       reader.on 'message', (msg) ->
-        shouldReceive.should.be.true
+        shouldReceive.should.be.true()
 
         reader.pause()
         msg.requeue()

--- a/test/message_test.coffee
+++ b/test/message_test.coffee
@@ -36,7 +36,7 @@ describe 'Message', ->
         msg.requeue()
 
       check = ->
-        responseSpy.calledOnce.should.be.true
+        responseSpy.calledOnce.should.be.true()
         done()
 
       setTimeout firstFinish, 10
@@ -61,9 +61,17 @@ describe 'Message', ->
         msg.finish()
 
       check = ->
-        responseSpy.calledTwice.should.be.true
+        responseSpy.calledTwice.should.be.true()
         done()
 
       setTimeout touch, touchIn
       setTimeout finish, finishIn
       setTimeout check, checkIn
+
+    it 'should clear timeout on finish', (done) ->
+      msg = createMessage 'body', 10, 60, 120
+      msg.finish()
+
+      process.nextTick ->
+        should.not.exist msg.trackTimeoutId
+        done()

--- a/test/nsqdconnection_test.coffee
+++ b/test/nsqdconnection_test.coffee
@@ -232,8 +232,8 @@ describe 'WriterConnectionState', ->
       statemachine.goto 'ERROR', 'lost connection'
 
     connection.on WriterNSQDConnection.CLOSED, ->
-      firstCb.calledOnce.should.be.ok
-      secondCb.calledOnce.should.be.ok
+      firstCb.calledOnce.should.be.ok()
+      secondCb.calledOnce.should.be.ok()
       done()
 
     statemachine.raise 'connecting'

--- a/test/reader_test.coffee
+++ b/test/reader_test.coffee
@@ -24,7 +24,7 @@ describe 'reader', ->
         reader.handleMessage message
 
         process.nextTick ->
-          message.finish.called.should.be.true
+          message.finish.called.should.be.true()
           done()
 
       it 'should call the DISCARD message hanlder if registered', (done) ->
@@ -72,6 +72,6 @@ describe 'reader', ->
       reader.handleMessage message
 
       process.nextTick ->
-        messageHandlerSpy.called.should.be.true
-        message.finish.called.should.be.false
+        messageHandlerSpy.called.should.be.true()
+        message.finish.called.should.be.false()
         done()

--- a/test/readerrdy_test.coffee
+++ b/test/readerrdy_test.coffee
@@ -84,7 +84,7 @@ describe 'ConnectionRdy', ->
     cRdy.setConnectionRdyMax 10
     cRdy.setRdy -1
 
-    spy.notCalled.should.be.ok
+    spy.notCalled.should.be.ok()
 
   it 'should not allow RDY counts to exceed the connection max', ->
     cRdy.setConnectionRdyMax 10
@@ -92,7 +92,7 @@ describe 'ConnectionRdy', ->
     cRdy.setRdy 10
     cRdy.setRdy 20
 
-    spy.calledTwice.should.be.ok
+    spy.calledTwice.should.be.ok()
     spy.firstCall.args[0].should.eql 9
     spy.secondCall.args[0].should.eql 10
 


### PR DESCRIPTION
Every message has a series of functions to track whether or not the message has timed out. The prior behavior just wanted for the timeout to expire instead of being cleared when the message has been replied to. This PR changes that now. 