### PR TITLE
De-dupe on broadcast_address instead of hostname

### DIFF
--- a/src/lookupd.coffee
+++ b/src/lookupd.coffee
@@ -49,7 +49,7 @@ dedupeOnHostPort = (results) ->
     .flatten()
     # De-dupe nodes by hostname / port
     .indexBy (item) ->
-      "#{item.hostname}:#{item.tcp_port}"
+      "#{item.broadcast_address}:#{item.tcp_port}"
     .values()
     .value()
 


### PR DESCRIPTION
With docker deployments it is common for the nsqd dockers to have the same hostname.

De-duping on the broadcast address rather than hostname (which is immutable with nsqd options) seems to make more sense. This solves a bug in our prod system where only one nsqd was being listened to at a time due to duplicate hostnames.