### PR TITLE
Add nsqlookupd api 1.0 request header

### DIFF
--- a/src/lookupd.coffee
+++ b/src/lookupd.coffee
@@ -16,7 +16,10 @@ lookupdRequest = (url, callback) ->
     url: url
     method: 'GET'
     json: true
-    timeout: 2000
+    timeout: 2000,
+    headers: {
+      'Accept': 'application/vnd.nsq; version=1.0'
+    }
 
   request options, (err, response, data) ->
     if err


### PR DESCRIPTION
In order to get same response from oder nsqlookupd (e.g. 0.3.8) header
`Accept: application/vnd.nsq; version=1.0`
is needed  to define api version 1.0

When **header is not set** older version of nsqlookupd (e.g. 0.3.8) responds with JSON
```json
{
    "status_code": 200,
    "status_txt": "OK",
    "data": {
        "channels": [],
        "producers": [
            {
                "remote_address": "127.0.0.1:37074",
                "hostname": "app1",
                "broadcast_address": "127.0.0.1",
                "tcp_port": 4150,
                "http_port": 4151,
                "version": "0.3.8"
            }
        ]
    }
}
```

When **header is set** older version of nsqlookupd (e.g. 0.3.8) responds with JSON same as version 1.0.0
```json
{
    "channels": [],
    "producers": [
        {
            "remote_address": "127.0.0.1:37074",
            "hostname": "app1",
            "broadcast_address": "127.0.0.1",
            "tcp_port": 4150,
            "http_port": 4151,
            "version": "0.3.8"
        }
    ]
}
```

This small patch allows parsing nsqlookupd responses as currently implemented.
Currently we have different version of nsq installed in production and development environments.
I have made this small patch by comparing go-nsq and Coffescript/JS code.

Interesting file in go-nsq:
https://github.com/nsqio/go-nsq/blob/master/api_request.go
