### PR TITLE
feature: support tls client certs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -22,6 +22,9 @@ class ConnectionConfig {
     snappy: false,
     tls: false,
     tlsVerification: true,
+    key: null,
+    cert: null,
+    ca: null,
   };
 
   /**
@@ -156,6 +159,30 @@ HTTP/HTTPS URI`
   }
 
   /**
+   * Throws an error if the option is not a buffer.
+   *
+   * @param  {String}  option
+   * @param  {*}  value
+   */
+  isBuffer(option, value) {
+    if (!Buffer.isBuffer(value)) {
+      throw new Error(`${option} must be a buffer`);
+    }
+  }
+
+  /**
+   * Throws an error if the option is not an array.
+   *
+   * @param  {String}  option
+   * @param  {*}  value
+   */
+  isArray(option, value) {
+    if (!_.isArray(value)) {
+      throw new Error(`${option} must be an array`);
+    }
+  }
+
+  /**
    * Returns the validated client config. Throws an error if any values are
    * not correct.
    *
@@ -177,6 +204,9 @@ HTTP/HTTPS URI`
       snappy: [this.isBoolean],
       tls: [this.isBoolean],
       tlsVerification: [this.isBoolean],
+      key: [this.isBuffer],
+      cert: [this.isBuffer],
+      ca: [this.isArray],
     };
   }
 

--- a/src/nsqdconnection.js
+++ b/src/nsqdconnection.js
@@ -187,6 +187,9 @@ class NSQDConnection extends EventEmitter {
     const options = {
       socket: this.conn,
       rejectUnauthorized: this.config.tlsVerification,
+      ca: this.config.ca,
+      key: this.config.key,
+      cert: this.config.cert
     };
 
     let tlsConn = tls.connect(options, () => {

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -124,6 +124,46 @@ describe('ConnectionConfig', () => {
     });
   });
 
+  describe('isBuffer', () => {
+    it('should require tls keys to be buffers', () => {
+      const check = () =>
+        config.isBuffer('key', new Buffer('a buffer'));
+      check.should.not.throw();
+    });
+
+    it('should require tls keys to be buffers', () => {
+      const check = () =>
+        config.isBuffer('key', 'not a buffer');
+      check.should.throw();
+    });
+
+    it('should require tls certs to be buffers', () => {
+      const check = () =>
+        config.isBuffer('cert', new Buffer('definitely a buffer'));
+      check.should.not.throw();
+    });
+
+    it('should throw when a tls cert is not a buffer', () => {
+      const check = () =>
+        config.isBuffer('cert', 'still not a buffer');
+      check.should.throw();
+    });
+  });
+
+  describe('isArray', () => {
+    it('should require cert authority chains to be arrays', () => {
+      const check = () =>
+        config.isArray('ca', ['cat', 'dog']);
+      check.should.not.throw();
+    });
+
+    it('should require cert authority chains to be arrays', () => {
+      const check = () =>
+        config.isArray('ca', 'not an array');
+      check.should.throw();
+    });
+  });
+
   describe('isBareAddresses', () => {
     it('should validate against a validate address list of 1', () => {
       const check = () =>


### PR DESCRIPTION
This change allows the client to connect to nsqd when it has client certs with `--tls-client-auth-policy require-verify` set.

See https://nodejs.org/api/tls.html#tls_tls_connect_options_callback for documentation of these options for `tls.connect()`.

- Added three new config options to the config validator: `key` for the client key, `cert` for the client cert, and `ca` for the cert authority chain.
- Added `isBuffer()` and `isArray()` checks to the config validator, along with tests that these function do what they advertise.
- Added these three options to the whitelisted set passed along to `tls.connect()` in NSQDConnection.