### PR TITLE
fix: in unit tests delayedStart was causing tests not to exit

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -70,7 +70,7 @@ class Message extends EventEmitter {
       this.trackTimeoutId = setTimeout(
         () => this.trackTimeout(),
         Math.min(soft, hard)
-      );
+      ).unref();
     }
   }
 

--- a/src/reader.js
+++ b/src/reader.js
@@ -87,7 +87,7 @@ class Reader extends EventEmitter {
       directConnect();
 
       // Start interval for connecting after delay.
-      setTimeout(delayedStart, delay);
+      setTimeout(delayedStart, delay).unref();
     }
 
     delayedStart = () => {
@@ -101,7 +101,7 @@ class Reader extends EventEmitter {
     this.queryLookupd();
 
     // Start interval for querying lookupd after delay.
-    setTimeout(delayedStart, delay);
+    setTimeout(delayedStart, delay).unref();
   }
 
   /**


### PR DESCRIPTION
in tests a few long lived `setTimeouts` were keeping the even loop open -- I think we're fairly safe to use `.unref()` on these timeouts; which makes for less bookkeeping when shutting down.