### PR TITLE
fix: lookupd was failing in my client, after updating to JS version of lib

### DIFF
--- a/src/lookupd.js
+++ b/src/lookupd.js
@@ -23,13 +23,18 @@ function lookupdRequest(url, callback) {
     timeout: 2000,
   };
 
-  request(options, (err, response, data = {}) => {
-    if (err || data.status_code !== 200) {
+  request(options, (err, response) => {
+    if (err) {
       return callback(err, []);
     }
 
+    const data = response.body
+    const statusCode = (data ? data.status_code : null) || response.statusCode
+    if (statusCode !== 200) {
+      return callback(null, []);
+    }
+
     try {
-      const { status_code: statusCode } = response;
       let { producers } = data;
 
       // Support pre version 1.x lookupd response.

--- a/src/lookupd.js
+++ b/src/lookupd.js
@@ -23,12 +23,11 @@ function lookupdRequest(url, callback) {
     timeout: 2000,
   };
 
-  request(options, (err, response) => {
+  request(options, (err, response, data={}) => {
     if (err) {
       return callback(err, []);
     }
 
-    const data = response.body
     const statusCode = (data ? data.status_code : null) || response.statusCode
     if (statusCode !== 200) {
       return callback(null, []);

--- a/src/lookupd.js
+++ b/src/lookupd.js
@@ -23,7 +23,7 @@ function lookupdRequest(url, callback) {
     timeout: 2000,
   };
 
-  request(options, (err, response, data={}) => {
+  request(options, (err, response, data = {}) => {
     if (err) {
       return callback(err, []);
     }

--- a/src/message.js
+++ b/src/message.js
@@ -57,6 +57,9 @@ class Message extends EventEmitter {
     this.trackTimeout();
   }
 
+  /**
+   * track whether or not a message has timed out.
+   */
   trackTimeout() {
     if (this.hasResponded) return;
 


### PR DESCRIPTION
after upgrading to the JavaScript version of the library, I noticed that the lookupd.js was looking for `data.status_code` -- which does not seem to be populated in the response payload in all cases.

I've added logic that falls back to `response.statusCode`, this gets my tests passing again.