### PR TITLE
chore: make snappystream optional, so that build step is not required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules/
 share/man
 src/node-*
 build
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
     "node-int64": "~0.3.0",
     "node-state": "~1.4.4",
     "request": "^2.79.0",
-    "snappystream": "^0.3.4",
     "underscore": "~1.5.2"
+  },
+  "optionalDependencies": {
+    "snappystream": "^0.3.4"
   }
 }

--- a/src/nsqdconnection.js
+++ b/src/nsqdconnection.js
@@ -7,7 +7,6 @@ import zlib from 'zlib';
 import NodeState from 'node-state';
 import _ from 'underscore';
 import debug from 'debug';
-import { SnappyStream, UnsnappyStream } from 'snappystream';
 
 import * as wire from './wire';
 import FrameBuffer from './framebuffer';
@@ -216,8 +215,9 @@ class NSQDConnection extends EventEmitter {
    * Create a snappy stream.
    */
   startSnappy() {
-    this.inflater = new UnsnappyStream();
-    this.deflater = new SnappyStream();
+    const snappystream = require('snappystream');
+    this.inflater = new snappystream.UnsnappyStream();
+    this.deflater = new snappystream.SnappyStream();
     this.reconsumeFrameBuffer();
   }
 

--- a/src/nsqdconnection.js
+++ b/src/nsqdconnection.js
@@ -215,10 +215,14 @@ class NSQDConnection extends EventEmitter {
    * Create a snappy stream.
    */
   startSnappy() {
-    const snappystream = require('snappystream');
-    this.inflater = new snappystream.UnsnappyStream();
-    this.deflater = new snappystream.SnappyStream();
-    this.reconsumeFrameBuffer();
+    try {
+      const snappystream = require('snappystream');
+      this.inflater = new snappystream.UnsnappyStream();
+      this.deflater = new snappystream.SnappyStream();
+      this.reconsumeFrameBuffer();
+    } catch (_err) {
+      console.warn('optional dependency snappystream could not be loaded')
+    }
   }
 
   /**


### PR DESCRIPTION
this pull makes the snappystream dependency optional -- this is nice because it allows nsqjs to be deployed to an environment that does not have the `node-gyp` build chain.

Since snappy is optional, and disabled by default, this seemed like a reasonable tweak that will make nsqjs work in more environments.