### PR TITLE
Make SnappyStream optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
+      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+      "optional": true
     },
     "acorn": {
       "version": "5.1.1",
@@ -67,12 +68,14 @@
     "aproba": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
+      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
+      "optional": true
     },
     "are-we-there-yet": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "optional": true,
       "requires": {
         "delegates": "1.0.0",
         "readable-stream": "2.3.3"
@@ -91,6 +94,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
       "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
+      "optional": true,
       "requires": {
         "debug": "2.6.8",
         "es6-symbol": "3.1.1"
@@ -100,6 +104,7 @@
           "version": "2.6.8",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -211,6 +216,7 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "optional": true,
       "requires": {
         "inherits": "2.0.3"
       }
@@ -326,7 +332,8 @@
     "coffee-script": {
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "optional": true
     },
     "color-convert": {
       "version": "1.9.0",
@@ -466,7 +473,8 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "optional": true
     },
     "diff": {
       "version": "3.2.0",
@@ -888,6 +896,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
       "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
+      "optional": true,
       "requires": {
         "aproba": "1.1.2",
         "console-control-strings": "1.1.0",
@@ -1021,7 +1030,8 @@
     "has-color": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+      "optional": true
     },
     "has-flag": {
       "version": "1.0.0",
@@ -1032,7 +1042,8 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "optional": true
     },
     "hawk": {
       "version": "3.1.3",
@@ -1116,7 +1127,8 @@
     "int24": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/int24/-/int24-0.0.1.tgz",
-      "integrity": "sha1-ls/xQwpGVXNS7bQGzYezCCs2nYQ="
+      "integrity": "sha1-ls/xQwpGVXNS7bQGzYezCCs2nYQ=",
+      "optional": true
     },
     "interpret": {
       "version": "1.0.3",
@@ -1211,7 +1223,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "optional": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -1558,6 +1571,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
       "integrity": "sha1-3aVYOTs+y74kyea4cDxxGUxj+jY=",
+      "optional": true,
       "requires": {
         "fstream": "1.0.11",
         "glob": "7.1.2",
@@ -1579,6 +1593,7 @@
           "version": "2.81.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "optional": true,
           "requires": {
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
@@ -1620,6 +1635,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "optional": true,
       "requires": {
         "abbrev": "1.1.0"
       }
@@ -1640,6 +1656,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
       "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM=",
+      "optional": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
         "console-control-strings": "1.1.0",
@@ -1704,6 +1721,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "optional": true,
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -1737,6 +1755,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
       "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
+      "optional": true,
       "requires": {
         "array-index": "1.0.0"
       }
@@ -2087,7 +2106,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "optional": true
     },
     "shelljs": {
       "version": "0.7.8",
@@ -2157,7 +2177,8 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "optional": true
     },
     "sinon": {
       "version": "1.7.3",
@@ -2178,6 +2199,7 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/snappy/-/snappy-5.0.5.tgz",
       "integrity": "sha1-7BiTI0aVRq7d5DWS94CICP0HO0U=",
+      "optional": true,
       "requires": {
         "bindings": "1.2.1",
         "nan": "2.3.5",
@@ -2188,6 +2210,7 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/snappystream/-/snappystream-0.3.4.tgz",
       "integrity": "sha1-85eGlatW02362yHjEq3uGCouV3c=",
+      "optional": true,
       "requires": {
         "async": "2.5.0",
         "coffee-script": "1.12.7",
@@ -2200,6 +2223,7 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "optional": true,
           "requires": {
             "lodash": "4.17.4"
           }
@@ -2245,6 +2269,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/sse4_crc32/-/sse4_crc32-5.1.1.tgz",
       "integrity": "sha1-Gi5zoKgQ4tabYF/t54nVZ4KaBLc=",
+      "optional": true,
       "requires": {
         "bindings": "1.2.1",
         "nan": "2.3.5"
@@ -2372,6 +2397,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "optional": true,
       "requires": {
         "block-stream": "0.0.9",
         "fstream": "1.0.11",
@@ -2501,6 +2527,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "optional": true,
       "requires": {
         "isexe": "2.0.0"
       }
@@ -2509,6 +2536,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "optional": true,
       "requires": {
         "string-width": "1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
     "moment": "^2.17.1",
     "node-int64": "~0.3.0",
     "node-state": "~1.4.4",
-    "request": "^2.79.0",
+    "request": "^2.79.0"
+  },
+  "optionalDependencies": {
     "snappystream": "^0.3.4"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -255,6 +255,14 @@ HTTP/HTTPS URI`
     if (this.snappy && this.deflate) {
       throw new Error('Cannot use both deflate and snappy');
     }
+
+    if (this.snappy) {
+      try {
+        require('snappystream')
+      } catch(err) {
+        throw new Error('Cannot use snappy since it did not successfully install via npm.')
+      }
+    }
   }
 }
 

--- a/src/nsqdconnection.js
+++ b/src/nsqdconnection.js
@@ -7,7 +7,6 @@ const zlib = require('zlib')
 const NodeState = require('node-state')
 const _ = require('lodash')
 const debug = require('debug')
-const {SnappyStream, UnsnappyStream} = require('snappystream')
 
 const wire = require('./wire')
 const FrameBuffer = require('./framebuffer')
@@ -216,6 +215,8 @@ class NSQDConnection extends EventEmitter {
    * Create a snappy stream.
    */
   startSnappy() {
+    const {SnappyStream, UnsnappyStream} = require('snappystream')
+
     this.inflater = new UnsnappyStream();
     this.deflater = new SnappyStream();
     this.reconsumeFrameBuffer();


### PR DESCRIPTION
* Move snappystream to optional dependency
* Throw an error if snappy is enabled in for a connection but the
package isn’t available.
* nsqdconnection requires snappy only when it’s about to be used.