### PR TITLE
Don't let lookupd request errors crash Reader

### DIFF
--- a/lib/lookupd.js
+++ b/lib/lookupd.js
@@ -1,8 +1,10 @@
 const _ = require('lodash')
 const async = require('async')
+const debug = require('debug')
 const request = require('request')
 const url = require('url')
 
+const log = debug('nsqjs:lookup')
 /**
  * lookupdRequest returns the list of producers from a lookupd given a
  * URL to query.
@@ -22,13 +24,18 @@ function lookupdRequest(url, callback) {
     timeout: 2000,
   };
 
-  request(options, (err, response, data = {}) => {
+  const requestWithRetry = cb => request(options, cb)
+  const retryOptions = {times: 3, interval: 500}
+
+  async.retry(retryOptions, requestWithRetry, (err, response, data = {}) => {
     if (err) {
-      return callback(err, []);
+      log(`lookup failed for ${url}`)
+      return callback(null, []);
     }
 
     const statusCode = (data ? data.status_code : null) || response.statusCode
     if (statusCode !== 200) {
+      log(`lookup failed for ${url}. Returned status code: ${statusCode}.`)
       return callback(null, []);
     }
 
@@ -42,6 +49,7 @@ function lookupdRequest(url, callback) {
 
       callback(null, producers);
     } catch (err) {
+      log(`lookup failed. Getting unsupported JSON back!`)
       callback(null, []);
     }
   });
@@ -77,7 +85,9 @@ const dedupedRequests = function(lookupdEndpoints, urlFn, callback) {
 
   return async.map(urls, lookupdRequest, (err, results) => {
     if (err) {
-      return callback(err, null);
+      // This should be very unlikely since lookupdRequest *shouldn't* be
+      // returning errors.
+      return callback(err, []);
     }
     return callback(null, dedupeOnHostPort(results));
   });

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -101,7 +101,7 @@ class Reader extends EventEmitter {
     this.queryLookupd();
 
     // Start interval for querying lookupd after delay.
-    setTimeout(delayedStart, delay).unref();
+    setTimeout(delayedStart, delay)
   }
 
   /**


### PR DESCRIPTION
* No known errors from a lookup failure should take down a Reader
* Log failures to perform a look up
* Don’t exist the Reader even if it fails to initially query a set of
lookups.