### PR TITLE
Better connection close behavior. Improved integration tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
   - $CXX --version
   - npm install
-  - wget "https://s3.amazonaws.com/bitly-downloads/nsq/nsq-0.3.5.linux-amd64.go1.4.2.tar.gz"
-  - tar zvxf "nsq-0.3.5.linux-amd64.go1.4.2.tar.gz"
-  - export PATH="$PATH:./nsq-0.3.5.linux-amd64.go1.4.2/bin"
+  - wget "https://s3.amazonaws.com/bitly-downloads/nsq/nsq-0.3.8.linux-amd64.go1.6.2.tar.gz"
+  - tar zvxf "nsq-0.3.8.linux-amd64.go1.6.2.tar.gz"
+  - export PATH="$PATH:./nsq-0.3.8.linux-amd64.go1.6.2/bin"
 script: npm test

--- a/lib/nsqdconnection.js
+++ b/lib/nsqdconnection.js
@@ -168,7 +168,7 @@ class NSQDConnection extends EventEmitter {
     conn.on('data', data => this.receiveRawData(data));
     conn.on('end', err => {
       this.statemachine.goto('CLOSED');
-      this.emit('connection_error', err);
+      //this.emit('connection_error', err);
     });
     conn.on('close', () => this.statemachine.raise('close'));
   }
@@ -407,7 +407,13 @@ touch_count=${msg.touchCount}]`
    * Destroy the nsqd connection.
    */
   destroy() {
-    this.conn.destroy();
+    if (!this.conn.destroyed) {
+      try {
+        this.conn.end(wire.close())
+      } catch (e) {
+        this.conn.destroy()
+      }
+    }
   }
 }
 

--- a/lib/nsqdconnection.js
+++ b/lib/nsqdconnection.js
@@ -170,7 +170,7 @@ class NSQDConnection extends EventEmitter {
       this.statemachine.goto('CLOSED');
     });
     conn.on('error', err => {
-      this.statemachine.goto('ERROR');
+      this.statemachine.goto('ERROR', err);
       this.emit('connection_error', err);
     });
     conn.on('close', () => this.statemachine.raise('close'));
@@ -407,15 +407,25 @@ touch_count=${msg.touchCount}]`
   }
 
   /**
+   * Close the nsqd connection.
+   */
+  close() {
+    if (!this.conn.destroyed 
+         || this.statemachine.current_state == 'CLOSED'
+         || this.statemachine.current_state == 'ERROR') {
+      try {
+        this.conn.end(wire.close())
+      } catch (e) {}
+    }
+    this.statemachine.goto('CLOSED');
+  }
+
+  /**
    * Destroy the nsqd connection.
    */
   destroy() {
     if (!this.conn.destroyed) {
-      try {
-        this.conn.end(wire.close())
-      } catch (e) {
-        this.conn.destroy()
-      }
+      this.conn.destroy()
     }
   }
 }

--- a/lib/nsqdconnection.js
+++ b/lib/nsqdconnection.js
@@ -411,8 +411,8 @@ touch_count=${msg.touchCount}]`
    */
   close() {
     if (!this.conn.destroyed 
-         || this.statemachine.current_state == 'CLOSED'
-         || this.statemachine.current_state == 'ERROR') {
+         && this.statemachine.current_state != 'CLOSED'
+         && this.statemachine.current_state != 'ERROR') {
       try {
         this.conn.end(wire.close())
       } catch (e) {}

--- a/lib/nsqdconnection.js
+++ b/lib/nsqdconnection.js
@@ -166,9 +166,12 @@ class NSQDConnection extends EventEmitter {
    */
   registerStreamListeners(conn) {
     conn.on('data', data => this.receiveRawData(data));
-    conn.on('end', err => {
+    conn.on('end', () => {
       this.statemachine.goto('CLOSED');
-      //this.emit('connection_error', err);
+    });
+    conn.on('error', err => {
+      this.statemachine.goto('ERROR');
+      this.emit('connection_error', err);
     });
     conn.on('close', () => this.statemachine.raise('close'));
   }

--- a/lib/readerrdy.js
+++ b/lib/readerrdy.js
@@ -67,7 +67,7 @@ class ConnectionRdy extends EventEmitter {
    * Close the reader ready connection.
    */
   close() {
-    this.conn.destroy();
+    this.conn.close();
   }
 
   /**

--- a/lib/wire.js
+++ b/lib/wire.js
@@ -178,6 +178,10 @@ function finish(id) {
   return command('FIN', null, id);
 }
 
+function close() {
+  return command('CLS', null);
+}
+
 /**
  * Emit a requeue command.
  *
@@ -316,6 +320,7 @@ module.exports = {
   FRAME_TYPE_RESPONSE,
   MAGIC_V2,
   auth,
+  close,
   dpub,
   finish,
   identify,

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -164,7 +164,7 @@ class Writer extends EventEmitter {
    * @return {undefined}
    */
   close() {
-    return this.conn.destroy();
+    return this.conn.close();
   }
 
   _serializeMsg(msg){

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "format": "prettier --single-quote --trailing-comma es5 --write \"{lib,test}/**/*.js\"",
     "lint": "eslint lib",
-    "test": "mocha -R spec"
+    "test": "mocha -R spec -b"
   },
   "main": "lib/nsq",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "format": "prettier --single-quote --trailing-comma es5 --write \"{lib,test}/**/*.js\"",
     "lint": "eslint lib",
-    "test": "mocha"
+    "test": "mocha -R spec"
   },
   "main": "lib/nsq",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-config-prettier": "^1.6.0",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-import": "^2.2.0",
-    "mocha": "^3.2",
+    "mocha": "^3.5",
     "nock": "~0.27.1",
     "prettier": "^0.22.0",
     "should": "^11.1.2",

--- a/test/nsqdconnection_test.js
+++ b/test/nsqdconnection_test.js
@@ -26,6 +26,7 @@ describe('Reader ConnectionState', () => {
       'channel_test'
     );
     sinon.stub(connection, 'write', data => sent.push(data.toString()));
+    sinon.stub(connection, 'close', () => {});
     sinon.stub(connection, 'destroy', () => {});
 
     const statemachine = new ConnectionState(connection);

--- a/test/readerrdy_test.js
+++ b/test/readerrdy_test.js
@@ -38,6 +38,9 @@ class StubNSQDConnection extends EventEmitter {
   connect() {};
 
   // Empty
+  close() {};
+
+  // Empty
   destroy() {};
 
   // Empty

--- a/test/z_integration_test.js
+++ b/test/z_integration_test.js
@@ -66,6 +66,13 @@ describe('integration', () => {
   let nsqdProcess = null;
   let reader = null;
 
+  beforeEach(done => createTopic('test', done));
+
+  afterEach(done => {
+    reader.close();
+    deleteTopic('test', done);
+  });
+
   before(done => {
     temp.mkdir('/nsq', (err, dirPath) => {
       if (err) return done(err);
@@ -83,12 +90,6 @@ describe('integration', () => {
     setTimeout(done, 500);
   });
 
-  beforeEach(done => createTopic('test', done));
-
-  afterEach(done => {
-    reader.close();
-    deleteTopic('test', done);
-  });
 
   describe('stream compression and encryption', () => {
     const optionPermutations = [

--- a/test/z_integration_test.js
+++ b/test/z_integration_test.js
@@ -26,8 +26,12 @@ const startNSQD = (dataPath, additionalOptions = {}, callback) => {
   // Convert to array for child_process.
   options = Object.keys(options).map(option => [`-${option}`, options[option]]);
 
+  // const process = child_process.spawn('nsqd', _.flatten(options), {
+  //   stdio: ['ignore', 'ignore', 'ignore'],
+  // });
   const process = child_process.spawn('nsqd', _.flatten(options), {
-    stdio: ['ignore', 'ignore', 'ignore'],
+    stdio: 'inherit',
+    shell: true
   });
 
   process.on('error', (err) => {

--- a/test/z_integration_test.js
+++ b/test/z_integration_test.js
@@ -26,8 +26,11 @@ const startNSQD = (dataPath, additionalOptions = {}, callback) => {
   // Convert to array for child_process.
   options = Object.keys(options).map(option => [`-${option}`, options[option]]);
 
+  // const process = child_process.spawn('nsqd', _.flatten(options), {
+  //   stdio: ['ignore', 'ignore', 'ignore'],
+  // });
   const process = child_process.spawn('nsqd', _.flatten(options), {
-    stdio: ['ignore', 'ignore', 'ignore'],
+    stdio: 'inherit'
   });
 
   process.on('error', (err) => {

--- a/test/z_integration_test.js
+++ b/test/z_integration_test.js
@@ -420,7 +420,6 @@ describe('failures', () => {
             callback => {
               nsqdProcess.on('exit', callback)
               nsqdProcess.kill('SIGKILL');
-              //setTimeout(callback, 500);
             },
 
             // Attempt to publish a message.

--- a/test/z_integration_test.js
+++ b/test/z_integration_test.js
@@ -122,7 +122,7 @@ describe('integration', () => {
         callback => {
           console.log('nsqd exit')
           nsqdProcess.on('exit', callback)
-          nsqdProcess.kill(9)
+          nsqdProcess.kill('SIGKILL')
         }
       ],
       err => {

--- a/test/z_integration_test.js
+++ b/test/z_integration_test.js
@@ -26,12 +26,8 @@ const startNSQD = (dataPath, additionalOptions = {}, callback) => {
   // Convert to array for child_process.
   options = Object.keys(options).map(option => [`-${option}`, options[option]]);
 
-  // const process = child_process.spawn('nsqd', _.flatten(options), {
-  //   stdio: ['ignore', 'ignore', 'ignore'],
-  // });
   const process = child_process.spawn('nsqd', _.flatten(options), {
-    stdio: 'inherit',
-    shell: true
+    stdio: ['ignore', 'ignore', 'ignore'],
   });
 
   process.on('error', (err) => {
@@ -93,9 +89,10 @@ describe('integration', () => {
   });
 
   after(done => {
+    nsqdProcess.on('exit', done)
     nsqdProcess.kill();
     // Give nsqd a chance to exit before it's data directory will be cleaned up.
-    setTimeout(done, 500);
+    //setTimeout(done, 500);
   });
 
 

--- a/test/z_integration_test.js
+++ b/test/z_integration_test.js
@@ -59,10 +59,6 @@ const topicOp = (op, topic, callback) => {
   request(options, err => callback(err));
 };
 
-// TODO: nsqd seems to be unhappy with how the connection is being closed.
-// We're not waiting for confirmation of the closed connection before trying
-// to delete the topic.
-// TODO: Try creating a new nsqd instance beforeEach
 const createTopic = _.partial(topicOp, 'topic/create');
 const deleteTopic = _.partial(topicOp, 'topic/delete');
 
@@ -303,7 +299,6 @@ describe('integration', () => {
         id.should.equal('');
         id = msg.id;
 
-        //if (reader.isPaused()) return done();
         reader.pause();
 
         // send it again, shouldn't get this one

--- a/test/z_integration_test.js
+++ b/test/z_integration_test.js
@@ -8,8 +8,8 @@ const nsq = require('../lib/nsq')
 
 const temp = require('temp').track();
 
-const TCP_PORT = 4150;
-const HTTP_PORT = 4151;
+let TCP_PORT = 4150;
+let HTTP_PORT = 4151;
 
 const startNSQD = (dataPath, additionalOptions = {}, callback) => {
   let options = {
@@ -29,9 +29,6 @@ const startNSQD = (dataPath, additionalOptions = {}, callback) => {
   const process = child_process.spawn('nsqd', _.flatten(options), {
     stdio: ['ignore', 'ignore', 'ignore'],
   });
-  // const process = child_process.spawn('nsqd', _.flatten(options), {
-  //   stdio: 'inherit'
-  // });
 
   process.on('error', (err) => {
     throw err
@@ -39,7 +36,7 @@ const startNSQD = (dataPath, additionalOptions = {}, callback) => {
 
   const retryOptions = {times: 10, interval: 50}
   const liveliness = (callback) => {
-    request('http://localhost:4151/ping', (err, res, body) => {
+    request(`http://localhost:${HTTP_PORT}/ping`, (err, res, body) => {
       if (err || res.statusCode != 200) {
         return callback(new Error('nsqd not ready'))
       }
@@ -48,7 +45,6 @@ const startNSQD = (dataPath, additionalOptions = {}, callback) => {
   }
 
   async.retry(retryOptions, liveliness, err => {callback(err, process)})
-  //setTimeout(() => callback(null, process), 500);
 };
 
 const topicOp = (op, topic, callback) => {
@@ -111,44 +107,30 @@ describe('integration', () => {
   })
 
   afterEach(done => {
-    reader.close()
     async.series(
       [
+        callback => {
+          reader.on('nsqd_closed', (nsqdAddress) => {callback()})
+          reader.close()
+        },
         callback => {deleteTopic('test', callback)},
         callback => {
-          nsqdProcess.on('exit', callback)
+          nsqdProcess.on('exit', err => {callback(err)})
           nsqdProcess.kill('SIGKILL')
         }
       ],
-      done
+      err => {
+        // After each start, increment the ports to prevent possible conflict the
+        // next time an NSQD instance is started. Sometimes NSQD instances do not
+        // exit cleanly causing odd behavior for tests and the test suite.
+        TCP_PORT = TCP_PORT + 50
+        HTTP_PORT = HTTP_PORT + 50
+
+        reader = null
+        done(err)
+      }
     )
   })
-
-  // beforeEach(done => createTopic('test', done));
-
-  // afterEach(done => {
-  //   reader.close();
-  //   deleteTopic('test', done);
-  // });
-
-  // before(done => {
-  //   temp.mkdir('/nsq', (err, dirPath) => {
-  //     if (err) return done(err);
-
-  //     startNSQD(dirPath, {}, (err, process) => {
-  //       nsqdProcess = process;
-  //       done(err);
-  //     });
-  //   });
-  // });
-
-  // after(done => {
-  //   nsqdProcess.on('exit', done)
-  //   nsqdProcess.kill();
-  //   // Give nsqd a chance to exit before it's data directory will be cleaned up.
-  //   //setTimeout(done, 500);
-  // });
-
 
   describe('stream compression and encryption', () => {
     const optionPermutations = [
@@ -224,7 +206,6 @@ describe('integration', () => {
   describe('end to end', () => {
     const topic = 'test';
     const channel = 'default';
-    const tcpAddress = `127.0.0.1:${TCP_PORT}`;
     let writer = null;
     reader = null;
 
@@ -232,18 +213,17 @@ describe('integration', () => {
       writer = new nsq.Writer('127.0.0.1', TCP_PORT);
       writer.on('ready', () => {
         reader = new nsq.Reader(topic, channel, {
-          nsqdTCPAddresses: tcpAddress,
+          nsqdTCPAddresses: [`127.0.0.1:${TCP_PORT}`],
         });
+        reader.on('nsqd_connected', addr => done())
         reader.connect();
-        done();
       });
 
       writer.on('error', () => {});
-
       writer.connect();
     });
 
-    afterEach(() => writer.close());
+    afterEach(() => {writer.close()});
 
     it('should send and receive a string', done => {
       const message = 'hello world';
@@ -251,7 +231,7 @@ describe('integration', () => {
         if (err) done(err);
       });
 
-      reader.on('error', () => {});
+      reader.on('error', err => {console.log(err)});
 
       reader.on('message', msg => {
         msg.body.toString().should.eql(message);
@@ -275,18 +255,9 @@ describe('integration', () => {
       });
     });
 
-    // TODO (Dudley): The behavior of nsqd seems to have changed around this.
-    //    This requires more investigation but not concerning at the moment.
-    it.skip('should not receive messages when immediately paused', done => {
-      let waitedLongEnough = false;
+    it('should not receive messages when immediately paused', done => {
 
-      const timeout = setTimeout(
-        () => {
-          reader.unpause();
-          waitedLongEnough = true;
-        },
-        100
-      );
+      setTimeout(done, 50)
 
       // Note: because NSQDConnection.connect() does most of it's work in
       // process.nextTick(), we're really pausing before the reader is
@@ -295,9 +266,7 @@ describe('integration', () => {
       reader.pause();
       reader.on('message', msg => {
         msg.finish();
-        clearTimeout(timeout);
-        waitedLongEnough.should.be.true();
-        done();
+        done(new Error('Should not have received a message while paused'))
       });
 
       writer.publish(topic, 'pause test');
@@ -320,7 +289,7 @@ describe('integration', () => {
         process.nextTick(() => {
           // send it again, shouldn't get this one
           writer.publish(topic, { messageShouldArrive: false });
-          setTimeout(done, 100);
+          setTimeout(done, 50);
         });
       });
     });
@@ -339,7 +308,7 @@ describe('integration', () => {
 
         // send it again, shouldn't get this one
         msg.requeue(0, false);
-        setTimeout(done, 100)
+        setTimeout(done, 50)
       });
 
       reader.on('error', err => {
@@ -348,28 +317,57 @@ describe('integration', () => {
     });
 
     it('should start receiving messages again after unpause', done => {
-      let shouldReceive = true;
-      writer.publish(topic, { sentWhilePaused: false });
+      let paused = false;
+      let handlerFn = null;
+      let afterHandlerFn = null;
+
+      const firstMessage = (msg) => {
+        reader.pause()
+        paused = true
+        msg.requeue()
+      };
+
+      const secondMessage = (msg) => {msg.finish()};
 
       reader.on('message', msg => {
-        should.equal(shouldReceive, true);
-        reader.pause();
-        msg.requeue();
+        should.equal(paused, false)
+        handlerFn(msg)
 
-        if (msg.json().sentWhilePaused) return done();
+        if (afterHandlerFn) {
+          afterHandlerFn()
+        }
+      })
 
-        shouldReceive = false;
-        writer.publish(topic, { sentWhilePaused: true });
-        setTimeout(
-          () => {
-            shouldReceive = true;
-            reader.unpause();
-          },
-          100
-        );
+      async.series([
+        // Publish and handle first message
+        callback => {
+          handlerFn = firstMessage
+          afterHandlerFn = callback
 
-        done();
-      });
+          writer.publish(topic, "not paused", (err) => {
+            if (err) {callback(err)}
+          })
+        },
+        // Publish second message
+        callback => {
+          afterHandlerFn = callback
+          writer.publish(topic, "paused", callback)
+        },
+        // Wait for 50ms
+        callback => {setTimeout(callback, 50)},
+        // Unpause. Processed queued message.
+        callback => {
+          handlerFn = secondMessage
+          // Note: We know a message was processed after unpausing when this
+          // callback is called. No need to explicitly note a 2nd message was
+          // processed.
+          afterHandlerFn = callback
+
+          reader.unpause()
+          paused = false
+        }],
+        done
+      )
     });
 
     it('should successfully publish a message before fully connected', done => {
@@ -420,8 +418,9 @@ describe('failures', () => {
 
             // Stop the nsqd process.
             callback => {
-              nsqdProcess.kill();
-              setTimeout(callback, 500);
+              nsqdProcess.on('exit', callback)
+              nsqdProcess.kill('SIGKILL');
+              //setTimeout(callback, 500);
             },
 
             // Attempt to publish a message.

--- a/test/z_integration_test.js
+++ b/test/z_integration_test.js
@@ -88,66 +88,66 @@ describe('integration', () => {
   let nsqdProcess = null;
   let reader = null;
 
-  // beforeEach(done => {
-  //   async.series(
-  //     [
-  //       // Start NSQD
-  //       callback => {
-  //         temp.mkdir('/nsq', (err, dirPath) => {
-  //           if (err) return callback(err)
+  beforeEach(done => {
+    async.series(
+      [
+        // Start NSQD
+        callback => {
+          temp.mkdir('/nsq', (err, dirPath) => {
+            if (err) return callback(err)
 
-  //           startNSQD(dirPath, {}, (err, process) => {
-  //             nsqdProcess = process
-  //             callback(err)
-  //           })
-  //         })
-  //       },
-  //       // Create the test topic
-  //       callback => {
-  //         createTopic('test', callback)
-  //       }
-  //     ],
-  //     done)
-  // })
-
-  // afterEach(done => {
-  //   reader.close()
-  //   async.series(
-  //     [
-  //       callback => {deleteTopic('test', callback)},
-  //       callback => {
-  //         nsqdProcess.on('exit', callback)
-  //         nsqdProcess.kill('SIGKILL')
-  //       }
-  //     ],
-  //     done
-  //   )
-  // })
-
-  beforeEach(done => createTopic('test', done));
+            startNSQD(dirPath, {}, (err, process) => {
+              nsqdProcess = process
+              callback(err)
+            })
+          })
+        },
+        // Create the test topic
+        callback => {
+          createTopic('test', callback)
+        }
+      ],
+      done)
+  })
 
   afterEach(done => {
-    reader.close();
-    deleteTopic('test', done);
-  });
+    reader.close()
+    async.series(
+      [
+        callback => {deleteTopic('test', callback)},
+        callback => {
+          nsqdProcess.on('exit', callback)
+          nsqdProcess.kill('SIGKILL')
+        }
+      ],
+      done
+    )
+  })
 
-  before(done => {
-    temp.mkdir('/nsq', (err, dirPath) => {
-      if (err) return done(err);
+  // beforeEach(done => createTopic('test', done));
 
-      startNSQD(dirPath, {}, (err, process) => {
-        nsqdProcess = process;
-        done(err);
-      });
-    });
-  });
+  // afterEach(done => {
+  //   reader.close();
+  //   deleteTopic('test', done);
+  // });
 
-  after(done => {
-    nsqdProcess.on('exit', done)
-    nsqdProcess.kill();
-    // Give nsqd a chance to exit before it's data directory will be cleaned up.
-    //setTimeout(done, 500);
-  });
+  // before(done => {
+  //   temp.mkdir('/nsq', (err, dirPath) => {
+  //     if (err) return done(err);
+
+  //     startNSQD(dirPath, {}, (err, process) => {
+  //       nsqdProcess = process;
+  //       done(err);
+  //     });
+  //   });
+  // });
+
+  // after(done => {
+  //   nsqdProcess.on('exit', done)
+  //   nsqdProcess.kill();
+  //   // Give nsqd a chance to exit before it's data directory will be cleaned up.
+  //   //setTimeout(done, 500);
+  // });
 
 
   describe('stream compression and encryption', () => {

--- a/test/z_integration_test.js
+++ b/test/z_integration_test.js
@@ -88,73 +88,66 @@ describe('integration', () => {
   let nsqdProcess = null;
   let reader = null;
 
-  beforeEach(done => {
-    async.series(
-      [
-        // Start NSQD
-        callback => {
-          temp.mkdir('/nsq', (err, dirPath) => {
-            if (err) return callback(err)
+  // beforeEach(done => {
+  //   async.series(
+  //     [
+  //       // Start NSQD
+  //       callback => {
+  //         temp.mkdir('/nsq', (err, dirPath) => {
+  //           if (err) return callback(err)
 
-            startNSQD(dirPath, {}, (err, process) => {
-              nsqdProcess = process
-              callback(err)
-            })
-          })
-        },
-        // Create the test topic
-        callback => {
-          createTopic('test', callback)
-        }
-      ],
-      done)
-  })
-
-  afterEach(done => {
-    async.series(
-      [
-        callback => {
-          console.log('closing')
-          reader.close()
-          setTimeout(callback, 200)
-        },
-        callback => {console.log('deleting topic'); deleteTopic('test', callback)},
-        callback => {
-          console.log('nsqd exit')
-          nsqdProcess.on('exit', callback)
-          nsqdProcess.kill('SIGKILL')
-        }
-      ],
-      err => {
-        console.log('cleaned up')
-        done(err)
-      })
-  })
-
-  // beforeEach(done => createTopic('test', done));
+  //           startNSQD(dirPath, {}, (err, process) => {
+  //             nsqdProcess = process
+  //             callback(err)
+  //           })
+  //         })
+  //       },
+  //       // Create the test topic
+  //       callback => {
+  //         createTopic('test', callback)
+  //       }
+  //     ],
+  //     done)
+  // })
 
   // afterEach(done => {
-  //   reader.close();
-  //   deleteTopic('test', done);
-  // });
+  //   reader.close()
+  //   async.series(
+  //     [
+  //       callback => {deleteTopic('test', callback)},
+  //       callback => {
+  //         nsqdProcess.on('exit', callback)
+  //         nsqdProcess.kill('SIGKILL')
+  //       }
+  //     ],
+  //     done
+  //   )
+  // })
 
-  // before(done => {
-  //   temp.mkdir('/nsq', (err, dirPath) => {
-  //     if (err) return done(err);
+  beforeEach(done => createTopic('test', done));
 
-  //     startNSQD(dirPath, {}, (err, process) => {
-  //       nsqdProcess = process;
-  //       done(err);
-  //     });
-  //   });
-  // });
+  afterEach(done => {
+    reader.close();
+    deleteTopic('test', done);
+  });
 
-  // after(done => {
-  //   nsqdProcess.on('exit', done)
-  //   nsqdProcess.kill();
-  //   // Give nsqd a chance to exit before it's data directory will be cleaned up.
-  //   //setTimeout(done, 500);
-  // });
+  before(done => {
+    temp.mkdir('/nsq', (err, dirPath) => {
+      if (err) return done(err);
+
+      startNSQD(dirPath, {}, (err, process) => {
+        nsqdProcess = process;
+        done(err);
+      });
+    });
+  });
+
+  after(done => {
+    nsqdProcess.on('exit', done)
+    nsqdProcess.kill();
+    // Give nsqd a chance to exit before it's data directory will be cleaned up.
+    //setTimeout(done, 500);
+  });
 
 
   describe('stream compression and encryption', () => {
@@ -313,6 +306,8 @@ describe('integration', () => {
     it('should not receive any new messages when paused', done => {
       writer.publish(topic, { messageShouldArrive: true });
 
+      reader.on('error', err => { console.log(err) })
+
       reader.on('message', msg => {
         // check the message
         msg.json().messageShouldArrive.should.be.true();
@@ -346,6 +341,10 @@ describe('integration', () => {
         msg.requeue(0, false);
         setTimeout(done, 100)
       });
+
+      reader.on('error', err => {
+        console.log(err)
+      })
     });
 
     it('should start receiving messages again after unpause', done => {

--- a/test/z_integration_test.js
+++ b/test/z_integration_test.js
@@ -30,6 +30,10 @@ const startNSQD = (dataPath, additionalOptions = {}, callback) => {
     stdio: ['ignore', 'ignore', 'ignore'],
   });
 
+  process.on('error', (err) => {
+    console.error(err)
+  })
+
   setTimeout(() => callback(null, process), 500);
 };
 


### PR DESCRIPTION
* Bump nsq version from `0.3.5` to `0.3.8`
* Have `nsqdconnection`s send `CLS` command when closing the connection.
* Add `close` method instead of using socket `destroy` to initiate a connection close.
* Bump mocha version
* Have tests fail on the first failing test.
* Use a different nsqd (on a different port) for each integration test
* Better setup and tear down of nsqd for integration tests
