### PR TITLE
support connection liveness conjecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ options object.
   sampleRate <= 99```
 * ```clientId: null```<br/>
   An identifier used to disambiguate this client.
-  
+* ```idleTimeout: 0``` <br/>
+  Socket timeout after idling for the duration in second (default to 0 means disabled).
 
 Reader events are:
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,6 +25,7 @@ class ConnectionConfig {
       key: null,
       cert: null,
       ca: null,
+      idleTimeout: 0
     };
   }
 
@@ -209,6 +210,7 @@ HTTP/HTTPS URI`
       key: [this.isBuffer],
       cert: [this.isBuffer],
       ca: [this.isArray],
+      idleTimeout: [this.isNumber, 0]
     };
   }
 

--- a/lib/nsqdconnection.js
+++ b/lib/nsqdconnection.js
@@ -174,6 +174,7 @@ class NSQDConnection extends EventEmitter {
       this.emit('connection_error', err);
     });
     conn.on('close', () => this.statemachine.raise('close'));
+    conn.setTimeout(this.config.idleTimeout * 1000, () => this.statemachine.raise('close'));
   }
 
   /**


### PR DESCRIPTION
additional options for reader and writer: `idleTimeout`
behavior: client close the connection when no ack received from nsqd in `idleTimeout` duration.

issues: #159 