### PR TITLE
backoff fn as a no-op while in backoff state

### DIFF
--- a/lib/readerrdy.js
+++ b/lib/readerrdy.js
@@ -694,10 +694,7 @@ ReaderRdy.prototype.states = {
       this.backoffTimer.failure();
       return this.backoff();
     },
-    backoff() {
-      this.backoffTimer.failure();
-      return this.backoff();
-    },
+    backoff() {}, // No-op
     success() {}, // No-op
     try() {
       return this.goto('TRY_ONE');

--- a/test/readerrdy_test.js
+++ b/test/readerrdy_test.js
@@ -683,6 +683,23 @@ describe('ReaderRdy', () => {
     });
   });
 
+  describe('backoff', () => {
+    it.only('should not increase interval with more failures during backoff', () => {
+      readerRdy = new ReaderRdy(100, 1, 'topic/channel', 0.01);
+
+      // Create a connection and make it ready.
+      const c = createNSQDConnection(0)
+      readerRdy.addConnection(c)
+      c.emit(NSQDConnection.READY)
+
+      readerRdy.raise('backoff')
+      const interval = readerRdy.backoffTimer.getInterval()
+
+      readerRdy.raise('backoff')
+      readerRdy.backoffTimer.getInterval().should.eql(interval)
+    });
+  });
+
   describe('pause / unpause', () => {
     beforeEach(() => {
       // Shortening the periodic `balance` calls to every 10ms. Changing the


### PR DESCRIPTION
Multiple failures while in backoff state would increase the
BackoffTimer interval. This would happen if a number of message
in-flight all ran into an error cause the Reader to backoff much longer
just because multiple messages failed at the same time.