### PR TITLE
resolves #186

### DIFF
--- a/lib/readerrdy.js
+++ b/lib/readerrdy.js
@@ -349,7 +349,7 @@ class ReaderRdy extends NodeState {
   close () {
     clearTimeout(this.backoffId)
     clearTimeout(this.balanceId)
-    return this.connections.map(conn => conn.close())
+    return _.clone(this.connections).map(conn => conn.close())
   }
 
   /**


### PR DESCRIPTION
I'm not sure this is the best way to fix this, but it's the only way I found out how. I tried altering the slice function further down in the code, but it always resulted in the array being modified in a way that wasn't conducive to the map. 

Cloning the map allows for all connections to be iterated over properly and closed out.

All tests pass locally including integration testing too. 