### PR TITLE
Simplify Reader.connect. Ensure exit on close.

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -58,7 +58,8 @@ class Reader extends EventEmitter {
       `${this.topic}/${this.channel}`
     )
 
-    this.connectIntervalId = null
+    this.lookupdIntervalId = null
+    this.directIntervalId = null
     this.connectionIds = []
   }
 
@@ -68,47 +69,42 @@ class Reader extends EventEmitter {
    * @return {undefined}
    */
   connect () {
-    let delayedStart
-    const interval = this.config.lookupdPollInterval * 1000
-    const delay = Math.random() * this.config.lookupdPollJitter * interval
+    this._connectTCPAddresses()
+    this._connectLookupd()
+  }
 
-    // Connect to provided nsqds.
-    if (this.config.nsqdTCPAddresses.length) {
-      const directConnect = () => {
-        // Don't establish new connections while the Reader is paused.
-        if (this.isPaused()) return
+  _connectInterval () {
+    return this.config.lookupdPollInterval * 1000
+  }
 
-        if (this.connectionIds.length < this.config.nsqdTCPAddresses.length) {
-          return this.config.nsqdTCPAddresses.forEach(addr => {
-            const [address, port] = addr.split(':')
-            this.connectToNSQD(address, Number(port))
-          })
-        }
+  _connectTCPAddresses () {
+    const directConnect = () => {
+      // Don't establish new connections while the Reader is paused.
+      if (this.isPaused()) return
+
+      if (this.connectionIds.length < this.config.nsqdTCPAddresses.length) {
+        return this.config.nsqdTCPAddresses.forEach(addr => {
+          const [address, port] = addr.split(':')
+          this.connectToNSQD(address, Number(port))
+        })
       }
-
-      delayedStart = () => {
-        this.connectIntervalId = setInterval(directConnect.bind(this), interval)
-      }
-
-      // Connect immediately.
-      directConnect()
-
-      // Start interval for connecting after delay.
-      setTimeout(delayedStart, delay).unref()
     }
 
-    delayedStart = () => {
-      this.connectIntervalId = setInterval(
-        this.queryLookupd.bind(this),
-        interval
-      )
-    }
+    this.lookupdIntervalId = setInterval(() => { directConnect() },
+      this._connectInterval())
+
+    // Connect immediately.
+    directConnect()
+  }
+
+  _connectLookupd () {
+    this.directIntervalId = setInterval(
+      () => { this.queryLookupd() },
+      this._connectInterval()
+    )
 
     // Connect immediately.
     this.queryLookupd()
-
-    // Start interval for querying lookupd after delay.
-    setTimeout(delayedStart, delay)
   }
 
   /**
@@ -116,7 +112,8 @@ class Reader extends EventEmitter {
    * @return {Array} The closed connections.
    */
   close () {
-    clearInterval(this.connectIntervalId)
+    clearInterval(this.directIntervalId)
+    clearInterval(this.lookupdIntervalId)
     return this.readerRdy.close()
   }
 


### PR DESCRIPTION
* Refactor Reader.connect
* Remove delayed start. Needlessly complex.
* Separate intervals for lookupd and direct connects
* Reader will stay connected until close and then intervals are cleaned
up