### PR TITLE
update moment package number which fixes redos vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "bignumber.js": "~4.1.0",
     "debug": "^3.0.1",
     "lodash": "^4.17.4",
-    "moment": "^2.17.1",
+    "moment": "^2.19.3",
     "node-int64": "~0.4.0",
     "node-state": "~1.4.4",
     "request": "^2.79.0"


### PR DESCRIPTION
Any package number lower will is caught by node security due to a redos vulnerability

https://nodesecurity.io/advisories/532 