### PR TITLE
Fix for #211

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -178,6 +178,7 @@ class Reader extends EventEmitter {
 
     // Ensure a connection doesn't already exist to this nsqd instance.
     if (this.connectionIds.indexOf(conn.id()) !== -1) {
+      conn.debug.destroy()
       return
     }
 


### PR DESCRIPTION
This is a quick fix that should take care of issue #211. It seems like the leak was caused by not cleaning up the debug.js instance after each periodic lookupd poll. We had `lookupdPollInterval` set to 10 so this issue was even more apparent.