### PR TITLE
update snappy stream version for node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "request": "^2.79.0"
   },
   "optionalDependencies": {
-    "snappystream": "^3.0.1"
+    "snappystream": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "request": "^2.79.0"
   },
   "optionalDependencies": {
-    "snappystream": "^1.1.0"
+    "snappystream": "^3.0.1"
   }
 }


### PR DESCRIPTION
Not sure if this is the right version?

The highest version is `1.1.0` but `1.0.1` is the newest one and has the newest version of snappystream that allows compatibility with Node 10.