### PR TITLE
[NSQDs] Fix timeout for identifying to NSQ

### DIFF
--- a/lib/nsqdconnection.js
+++ b/lib/nsqdconnection.js
@@ -164,7 +164,7 @@ class NSQDConnection extends EventEmitter {
           // identify response.
           this.identifyTimeoutId = setTimeout(() => {
             this.identifyTimeout()
-          }, 500)
+          }, 5000)
 
           this.identifyTimeoutId
         }


### PR DESCRIPTION
After using this library in production for a while, we regularly encounter the `Timed out identifying with nsqd` error. Moreover, the [comments](https://github.com/dudleycarr/nsqjs/blob/d9d4c847d25de14cd5daee1e2af2f61e87c8092b/lib/nsqdconnection.js#L167) do specify 5 seconds before timeout and the code only seems to wait for 0.5 seconds. Hence I updated the duration. This PR fixes https://github.com/dudleycarr/nsqjs/issues/232.