### PR TITLE
Fix Reader close behavior. Add Reader ready and not ready events

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ options object.
 
 Reader events are:
 
+* `Reader.READY` or `ready`
+* `Reader.NOT_READY` or `not_ready`
 * `Reader.MESSAGE` or `message`
 * `Reader.DISCARD` or `discard`
 * `Reader.ERROR` or `error`
@@ -286,6 +288,12 @@ w.on('closed', () => {
 
 Changes
 -------
+* **0.11.0**
+  * Support NodeJS 10
+  * Fix Snappy issues with NSQD 1.0 and 1.1
+  * Fix `close` behavior for Readers
+  * Added `"ready"` and `"not_ready"` events for Reader.
+  * Fix short timeout for connection IDENTIFY requests. (Thanks @emaincourt)
 * **0.10.1**
   * Fix debug.js memory leak when destroying NSQDConnection objects.
 * **0.10.0**

--- a/lib/nsqdconnection.js
+++ b/lib/nsqdconnection.js
@@ -495,12 +495,20 @@ ConnectionState.prototype.states = {
   INIT: {
     connecting () {
       return this.goto('CONNECTING')
+    },
+
+    close () {
+      return this.goto('CLOSED')
     }
   },
 
   CONNECTING: {
     connected () {
       return this.goto('CONNECTED')
+    },
+
+    close () {
+      return this.goto('CLOSED')
     }
   },
 
@@ -550,6 +558,10 @@ ConnectionState.prototype.states = {
         return this.goto('TLS_START')
       }
       return this.goto('IDENTIFY_COMPRESSION_CHECK')
+    },
+
+    close () {
+      return this.goto('CLOSED')
     }
   },
 
@@ -580,6 +592,10 @@ ConnectionState.prototype.states = {
         return this.goto('IDENTIFY_COMPRESSION_CHECK')
       }
       return this.goto('ERROR', new Error('TLS negotiate error with nsqd'))
+    },
+
+    close () {
+      return this.goto('CLOSED')
     }
   },
 
@@ -606,6 +622,10 @@ ConnectionState.prototype.states = {
         'ERROR',
         new Error('Bad response when enabling compression')
       )
+    },
+
+    close () {
+      return this.goto('CLOSED')
     }
   },
 
@@ -623,6 +643,10 @@ ConnectionState.prototype.states = {
     response (data) {
       this.conn.auth = JSON.parse(data)
       return this.goto(this.afterIdentify())
+    },
+
+    close () {
+      return this.goto('CLOSED')
     }
   },
 
@@ -641,6 +665,10 @@ ConnectionState.prototype.states = {
         // phase. Do this only once for a connection.
         return this.conn.emit(NSQDConnection.READY)
       }
+    },
+
+    close () {
+      return this.goto('CLOSED')
     }
   },
 

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -21,6 +21,12 @@ class Reader extends EventEmitter {
   static get MESSAGE () {
     return 'message'
   }
+  static get READY () {
+    return 'ready'
+  }
+  static get NOT_READY () {
+    return 'not_ready'
+  }
   static get DISCARD () {
     return 'discard'
   }
@@ -61,6 +67,7 @@ class Reader extends EventEmitter {
     this.lookupdIntervalId = null
     this.directIntervalId = null
     this.connectionIds = []
+    this.isClosed = false
   }
 
   /**
@@ -112,6 +119,7 @@ class Reader extends EventEmitter {
    * @return {Array} The closed connections.
    */
   close () {
+    this.isClosed = true
     clearInterval(this.directIntervalId)
     clearInterval(this.lookupdIntervalId)
     return this.readerRdy.close()
@@ -167,6 +175,10 @@ class Reader extends EventEmitter {
    * @return {Object|undefined} The newly created nsqd connection.
    */
   connectToNSQD (host, port) {
+    if (this.isClosed) {
+      return
+    }
+
     this.debug(`discovered ${host}:${port} for ${this.topic} topic`)
     const conn = new NSQDConnection(
       host,
@@ -201,6 +213,14 @@ class Reader extends EventEmitter {
       this.emit(Reader.NSQD_CONNECTED, conn.nsqdHost, conn.nsqdPort)
     })
 
+    conn.on(NSQDConnection.READY, () => {
+      // Emit only if this is the first connection for this Reader.
+      if (this.connectionIds.length === 1) {
+        this.debug(Reader.READY)
+        this.emit(Reader.READY)
+      }
+    })
+
     conn.on(NSQDConnection.ERROR, err => {
       this.debug(Reader.ERROR)
       this.debug(err)
@@ -224,6 +244,11 @@ class Reader extends EventEmitter {
       this.connectionIds.splice(index, 1)
 
       this.emit(Reader.NSQD_CLOSED, conn.nsqdHost, conn.nsqdPort)
+
+      if (this.connectionIds.length === 0) {
+        this.debug(Reader.NOT_READY)
+        this.emit(Reader.NOT_READY)
+      }
     })
 
     /**

--- a/lib/readerrdy.js
+++ b/lib/readerrdy.js
@@ -339,6 +339,7 @@ class ReaderRdy extends NodeState {
     this.balanceId = null
     this.connections = []
     this.roundRobinConnections = new RoundRobinList([])
+    this.isClosed = false
   }
 
   /**
@@ -347,6 +348,7 @@ class ReaderRdy extends NodeState {
    * @return {Array} The closed connections.
    */
   close () {
+    this.isClosed = true
     clearTimeout(this.backoffId)
     clearTimeout(this.balanceId)
     return _.clone(this.connections).map(conn => conn.close())
@@ -460,6 +462,13 @@ class ReaderRdy extends NodeState {
     conn.on(NSQDConnection.BACKOFF, () => this.raise('backoff'))
 
     connectionRdy.on(ConnectionRdy.READY, () => {
+      // Aborting the connection. ReaderRdy received a close while the
+      //   nsqdConnection was still being established.
+      if (this.isClosed) {
+        conn.close()
+        return
+      }
+
       this.connections.push(connectionRdy)
       this.roundRobinConnections.add(connectionRdy)
 


### PR DESCRIPTION
Reader close behavior didn't account for connections being opened when close is called.

Reader now emits `"ready"` when the first `nsqd_connection` has fully been negotiated. Reader emits `"not_ready"` when the last `nsqd_connection"` has been closed.

Fixes #207 