### PR TITLE
fix: Allow connect to ipv6 addresses

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,29 @@
 const _ = require('lodash')
 const url = require('url')
+const net = require('net')
+
+function joinHostPort(host, port) {
+  if (net.isIPv6(host)) {
+    return `[${host}]:${port}`
+  }
+
+  return `${host}:${port}`
+}
+
+function splitHostPort(addr) {
+  const parts = addr.split(':')
+  const port = parts[parts.length - 1]
+  let host = parts.slice(0, parts.length - 1).join()
+
+  if (host[0] === '[' && host[host.length - 1] === ']') {
+    host = host.slice(1, host.length - 1)
+  }
+
+  return [
+    host,
+    port,
+  ]
+}
 
 /**
  * Responsible for configuring the official defaults for nsqd connections.
@@ -36,7 +60,7 @@ class ConnectionConfig {
    * @return {Boolean}
    */
   static isBareAddress(addr) {
-    const [host, port] = addr.split(':')
+    const [host, port] = splitHostPort(addr)
     return host.length > 0 && port > 0
   }
 
@@ -338,4 +362,4 @@ class ReaderConfig extends ConnectionConfig {
   }
 }
 
-module.exports = {ConnectionConfig, ReaderConfig}
+module.exports = {ConnectionConfig, ReaderConfig, joinHostPort, splitHostPort}

--- a/lib/lookupd.js
+++ b/lib/lookupd.js
@@ -1,6 +1,7 @@
 const debug = require('./debug')
 const fetch = require('node-fetch')
 const url = require('url')
+const {joinHostPort} = require('./config')
 
 const log = debug('nsqjs:lookup')
 /**
@@ -43,8 +44,8 @@ function dedupeOnHostPort(results) {
   for (const lookupdResult of results) {
     for (const item of lookupdResult) {
       const key = item.broadcast_address
-        ? `${item.broadcast_address}:${item.tcp_port}`
-        : `${item.hostname}:${item.tcp_port}`
+        ? joinHostPort(item.broadcast_address, item.tcp_port)
+        : joinHostPort(item.hostname, item.tcp_port)
       uniqueNodes[key] = item
     }
   }

--- a/lib/nsqdconnection.js
+++ b/lib/nsqdconnection.js
@@ -12,7 +12,7 @@ const wire = require('./wire')
 const FrameBuffer = require('./framebuffer')
 const Message = require('./message')
 const version = require('./version')
-const {ConnectionConfig} = require('./config')
+const {ConnectionConfig, joinHostPort} = require('./config')
 
 /**
  * NSQDConnection is a reader connection to a nsqd instance. It manages all
@@ -136,7 +136,7 @@ class NSQDConnection extends EventEmitter {
    * @return {[type]} [description]
    */
   id() {
-    return `${this.nsqdHost}:${this.nsqdPort}`
+    return joinHostPort(this.nsqdHost, this.nsqdPort)
   }
 
   /**

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -5,7 +5,7 @@ const debug = require('./debug')
 const RoundRobinList = require('./roundrobinlist')
 const lookup = require('./lookupd')
 const {NSQDConnection} = require('./nsqdconnection')
-const {ReaderConfig} = require('./config')
+const {ReaderConfig, splitHostPort, joinHostPort} = require('./config')
 const {ReaderRdy} = require('./readerrdy')
 
 /**
@@ -92,7 +92,7 @@ class Reader extends EventEmitter {
 
       if (this.connectionIds.length < this.config.nsqdTCPAddresses.length) {
         return this.config.nsqdTCPAddresses.forEach((addr) => {
-          const [address, port] = addr.split(':')
+          const [address, port] = splitHostPort(addr)
           this.connectToNSQD(address, Number(port))
         })
       }
@@ -180,7 +180,7 @@ class Reader extends EventEmitter {
       return
     }
 
-    this.debug(`discovered ${host}:${port} for ${this.topic} topic`)
+    this.debug(`discovered ${joinHostPort(host, port)} for ${this.topic} topic`)
     const conn = new NSQDConnection(
       host,
       port,
@@ -194,7 +194,7 @@ class Reader extends EventEmitter {
       return
     }
 
-    this.debug(`connecting to ${host}:${port}`)
+    this.debug(`connecting to ${joinHostPort(host, port)}`)
     this.connectionIds.push(conn.id())
 
     this.registerConnectionListeners(conn)

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -2,7 +2,7 @@ const _ = require('lodash')
 const debug = require('./debug')
 const {EventEmitter} = require('events')
 
-const {ConnectionConfig} = require('./config')
+const {ConnectionConfig, joinHostPort} = require('./config')
 const {WriterNSQDConnection} = require('./nsqdconnection')
 
 /**
@@ -53,7 +53,7 @@ class Writer extends EventEmitter {
     // while the Writer is connecting.
     this.setMaxListeners(10000)
 
-    this.debug = debug(`nsqjs:writer:${this.nsqdHost}/${this.nsqdPort}`)
+    this.debug = debug(`nsqjs:writer:${joinHostPort(this.nsqdHost, this.nsqdPort)}`)
     this.config = new ConnectionConfig(options)
     this.config.validate()
     this.ready = false

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -166,6 +166,12 @@ describe('ConnectionConfig', () => {
       check.should.not.throw()
     })
 
+    it('should validate against a validate ipv6 address list of 1', () => {
+      const check = () =>
+        config.isBareAddresses('nsqdTCPAddresses', ['[::1]:4150'])
+      check.should.not.throw()
+    })
+
     it('should validate against a validate address list of 2', () => {
       const check = () => {
         const addrs = ['127.0.0.1:4150', 'localhost:4150']
@@ -174,9 +180,21 @@ describe('ConnectionConfig', () => {
       check.should.not.throw()
     })
 
+    it('should validate against a validate ipv6 address list of 2', () => {
+      const check = () =>
+        config.isBareAddresses('nsqdTCPAddresses', ['[::1]:4150', '[::]:4150'])
+      check.should.not.throw()
+    })
+
     it('should not validate non-numeric port', () => {
       const check = () =>
         config.isBareAddresses('nsqdTCPAddresses', ['localhost'])
+      check.should.throw()
+    })
+
+    it('should invalidate ipv6 address port', () => {
+      const check = () =>
+        config.isBareAddresses('nsqdTCPAddresses', ['[::1]'])
       check.should.throw()
     })
   })
@@ -195,6 +213,8 @@ describe('ConnectionConfig', () => {
         const addrs = [
           '127.0.0.1:4150',
           'localhost:4150',
+          '[::1]:4150',
+          '[::]:4150',
           'http://localhost/nsq/lookup',
           'https://localhost/nsq/lookup',
         ]


### PR DESCRIPTION
Thanks for the great lib :)

When a client tries to connect to a nsqd behind an IPv6 address, the client would throw errors like:

```
Error: lookupdHTTPAddresses must be a list of addresses 'host:port' or HTTP/HTTPS URI
```

I think it's because passing ipv6 addresses, e.g. `[::1]:4150` , to `isBareAddress()` would make it return false:

https://github.com/dudleycarr/nsqjs/blob/8956c69ad978452ffe9a7fd7c11dd276846aa324/lib/config.js#L38-L41


Feel free to close this PR if there is a better solution.