### PR TITLE
Refactor compression start. Fix race processing race condition.

### DIFF
--- a/lib/nsqdconnection.js
+++ b/lib/nsqdconnection.js
@@ -128,6 +128,7 @@ class NSQDConnection extends EventEmitter {
 
     this.writeQueue = []
     this.onDataFn = null
+    this.outWriter = null
   }
 
   /**
@@ -173,6 +174,7 @@ class NSQDConnection extends EventEmitter {
         }
       )
       this.conn.setNoDelay(true)
+      this.outWriter = this.conn
 
       this.registerStreamListeners(this.conn)
     })
@@ -222,7 +224,32 @@ class NSQDConnection extends EventEmitter {
       typeof callback === 'function' ? callback() : undefined
     })
 
+    this.outWriter = tlsConn
     this.registerStreamListeners(tlsConn)
+  }
+
+  /**
+   * startCompression wraps the TCP connection stream.
+   *
+   * @param {Stream} inflater - Decompression stream
+   * @param {Stream} deflater - Compression stream
+   */
+  startCompression(inflater, deflater) {
+    this.inflater = inflater
+    this.deflater = deflater
+
+    this.conn.removeListener('data', this.onDataFn)
+    this.conn.pipe(this.inflater)
+    this.inflater.on('data', this.onDataFn)
+
+    this.outWriter = this.deflater
+    this.outWriter.pipe(this.conn)
+
+    if (this.frameBuffer.buffer) {
+      const b = this.frameBuffer.buffer
+      this.frameBuffer.buffer = null
+      setImmediate(() => this.inflater.write(b))
+    }
   }
 
   /**
@@ -232,21 +259,13 @@ class NSQDConnection extends EventEmitter {
    * @param  {Number} level
    */
   startDeflate(level) {
-    this.inflater = zlib.createInflateRaw({flush: zlib.constants.Z_SYNC_FLUSH})
-    this.deflater = zlib.createDeflateRaw({
-      level,
-      flush: zlib.constants.Z_SYNC_FLUSH,
-    })
-
-    this.conn.removeListener('data', this.onDataFn)
-    this.conn.pipe(this.inflater)
-    this.inflater.on('data', this.onDataFn)
-
-    if (this.frameBuffer.buffer) {
-      const b = this.frameBuffer.buffer
-      this.frameBuffer.buffer = null
-      this.inflater.write(b)
-    }
+    this.startCompression(
+      zlib.createInflateRaw({flush: zlib.constants.Z_SYNC_FLUSH}),
+      zlib.createDeflateRaw({
+        level,
+        flush: zlib.constants.Z_SYNC_FLUSH,
+      })
+    )
   }
 
   /**
@@ -254,19 +273,7 @@ class NSQDConnection extends EventEmitter {
    */
   startSnappy() {
     const {SnappyStream, UnsnappyStream} = require('snappystream')
-
-    this.inflater = new UnsnappyStream()
-    this.deflater = new SnappyStream()
-
-    this.conn.removeListener('data', this.onDataFn)
-    this.conn.pipe(this.inflater)
-    this.inflater.on('data', this.onDataFn)
-
-    if (this.frameBuffer.buffer) {
-      const b = this.frameBuffer.buffer
-      this.frameBuffer.buffer = null
-      this.inflater.write(b)
-    }
+    this.startCompression(new UnsnappyStream(), new SnappyStream())
   }
 
   /**
@@ -412,11 +419,11 @@ touch_count=${msg.touchCount}]`
    * @param  {Object} data
    */
   write(data) {
-    if (_.isString(data)) {
-      data = Buffer.from(data)
+    if (Buffer.isBuffer(data)) {
+      this.outWriter.write(data)
+    } else {
+      this.outWriter.write(Buffer.from(data))
     }
-    this.writeQueue.push(data)
-    setImmediate(() => this._flush())
   }
 
   _flush() {


### PR DESCRIPTION
Refactored the handling of compression start for deflate and snappy. 

Fixed a race condition processing issue. Without the `setImmedate` around the processing of the buffered compressed content, `receivedData` would be called while a frame was being processed leading to connection hanging.