### PR TITLE
docs(roundrobinlist.js): fix usage

### DIFF
--- a/lib/roundrobinlist.js
+++ b/lib/roundrobinlist.js
@@ -7,7 +7,7 @@
  *   list.next() ==> [1]
  *   list.next(2) ==> [2, 3]
  *   list.next(2) ==> [1, 2]
- *   list.add(5) ==> 5
+ *   list.add(5) ==> 4
  *   list.next(2) ==> [3, 5]
  */
 class RoundRobinList {


### PR DESCRIPTION
push() returns the new length

```javascript
const RRL = require('./lib/roundrobinlist');

const list = new RRL([1, 2, 3]);

console.log(list.next());
console.log(list.next(2));
console.log(list.next(2));
console.log(list.add(5));
console.log(list.next(2));
```